### PR TITLE
scripts: Update install-cni

### DIFF
--- a/script/setup/install-cni
+++ b/script/setup/install-cni
@@ -21,7 +21,8 @@
 #
 set -eu -o pipefail
 
-CNI_COMMIT=${1:-$(grep containernetworking/plugins "$GOPATH"/src/github.com/containerd/containerd/go.mod | awk '{print $2}')}
+project_root=$(cd $(dirname "$0")/../../;pwd)
+CNI_COMMIT=${1:-$(grep containernetworking/plugins "${project_root}/go.mod" | awk '{print $2}')}
 CNI_DIR=${DESTDIR:=''}/opt/cni
 CNI_CONFIG_DIR=${DESTDIR}/etc/cni/net.d
 


### PR DESCRIPTION
When running `install_cri_containerd.sh` in kata-containers/test we are hitting:
```
12:30:49 DESTDIR=/tmp/jenkins/workspace/kata-containers-CCv0-tests-firecracker-ubuntu-PR/go/src/github.com/confidential-containers/containerd/_output/cri script/setup/install-cni
12:30:49 grep: /tmp/jenkins/workspace/kata-containers-CCv0-tests-firecracker-ubuntu-PR/go/src/github.com/containerd/containerd/go.mod: No such file or directory
12:30:49 Makefile:298: recipe for target 'install-cri-deps' failed
12:30:49 make: *** [install-cri-deps] Error 2
```
This is due to the install-cni-script using a hard-coded path to the containerd go mod.

This commit update install-cni script to stop it being hard-coded to the containerd org, which we need for testing our fork

Signed-off-by: stevenhorsman <steven@uk.ibm.com>