### PR TITLE
release: Allow releasing a binary from our fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,21 +18,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}
-          path: src/github.com/containerd/containerd
-
-      - name: Check signature
-        run: |
-          releasever=${{ github.ref }}
-          releasever="${releasever#refs/tags/}"
-          TAGCHECK=$(git tag -v ${releasever} 2>&1 >/dev/null) ||
-          echo "${TAGCHECK}" | grep -q "error" && {
-              echo "::error::tag ${releasever} is not a signed tag. Failing release process."
-              exit 1
-          } || {
-              echo "Tag ${releasever} is signed."
-              exit 0
-          }
-        working-directory: src/github.com/containerd/containerd
+          path: src/github.com/confidential-containers/containerd
 
       - name: Release content
         id: contentrel
@@ -40,13 +26,13 @@ jobs:
           RELEASEVER=${{ github.ref }}
           echo "::set-output name=stringver::${RELEASEVER#refs/tags/v}"
           git tag -l ${RELEASEVER#refs/tags/} -n20000 | tail -n +3 | cut -c 5- >release-notes.md
-        working-directory: src/github.com/containerd/containerd
+        working-directory: src/github.com/confidential-containers/containerd
 
       - name: Save release notes
         uses: actions/upload-artifact@v2
         with:
           name: containerd-release-notes
-          path: src/github.com/containerd/containerd/release-notes.md
+          path: src/github.com/confidential-containers/containerd/release-notes.md
 
   build:
     name: Build Release Binaries
@@ -86,7 +72,7 @@ jobs:
           # See https://github.com/containerd/containerd/issues/5098 for the context.
           repository: ${{ github.repository }}
           ref: ${{ github.ref }}
-          path: src/github.com/containerd/containerd
+          path: src/github.com/confidential-containers/containerd
 
       - name: Setup buildx instance
         uses: docker/setup-buildx-action@v1
@@ -109,7 +95,7 @@ jobs:
 
           # Remove symlinks since we don't want these in the release Artifacts
           find ./releases/ -maxdepth 1 -type l | xargs rm
-        working-directory: src/github.com/containerd/containerd
+        working-directory: src/github.com/confidential-containers/containerd
         env:
           GO_VERSION: '1.17.13'
           PLATFORM: ${{ matrix.platform }}
@@ -117,7 +103,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: release-tars-${{env.PLATFORM_CLEAN}}
-          path: src/github.com/containerd/containerd/releases/*.tar.gz*
+          path: src/github.com/confidential-containers/containerd/releases/*.tar.gz*
 
   release:
     name: Create containerd Release


### PR DESCRIPTION
And avoiding building the binary on every single GitHub action run on Kata Containers / Confidential Containers.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>