### PR TITLE
release: Remove windows target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,6 @@ jobs:
           # riscv64 isn't supported by Ubuntu 18.04
           - ubuntu: 22.04
             platform: linux/riscv64
-          - ubuntu: 18.04
-            platform: windows/amd64
     steps:
       - name: Set env
         shell: bash


### PR DESCRIPTION
For the CoCo usage we don't need to build the Windows binaries, and those are failing as part of our workflow.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>