### PR TITLE
CI: update GHA instances from Ubuntu 18.04 to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,16 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.17.13]
-        os: [ubuntu-18.04, macos-12, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
 
     steps:
-      - uses: actions/setup-go@v2
+      - name: Install dependencies
+        if: matrix.os == 'ubuntu-20.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libbtrfs-dev
+
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -40,7 +45,7 @@ jobs:
   #
   project:
     name: Project Checks
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 5
 
     steps:
@@ -68,7 +73,7 @@ jobs:
   #
   protos:
     name: Protobuf
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 5
 
     defaults:
@@ -104,7 +109,7 @@ jobs:
 
   man:
     name: Manpages
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 5
 
     steps:
@@ -221,11 +226,16 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-12, windows-2019, windows-2022]
-        go-version: ['1.16.15', '1.17.13']
-
+        os: [ubuntu-20.04, macos-12, windows-2019, windows-2022]
+        go-version: ["1.19.2", "1.18.7"]
     steps:
-      - uses: actions/setup-go@v2
+      - name: Install dependencies
+        if: matrix.os == 'ubuntu-20.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libbtrfs-dev
+
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -339,7 +349,7 @@ jobs:
 
   integration-linux:
     name: Linux Integration
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 40
     needs: [project, linters, protos, man]
 
@@ -368,11 +378,12 @@ jobs:
           RUNC_FLAVOR: ${{ matrix.runc }}
           GOFLAGS: -modcacherw
         run: |
-          sudo apt-get install -y gperf
-          sudo -E PATH=$PATH script/setup/install-seccomp
-          sudo -E PATH=$PATH script/setup/install-runc
-          sudo -E PATH=$PATH script/setup/install-cni $(grep containernetworking/plugins go.mod | awk '{print $2}')
-          sudo -E PATH=$PATH script/setup/install-critools
+          sudo apt-get install -y gperf libbtrfs-dev
+          script/setup/install-seccomp
+          script/setup/install-runc
+          script/setup/install-cni $(grep containernetworking/plugins go.mod | awk '{print $2}')
+          script/setup/install-critools
+          script/setup/install-failpoint-binaries
 
       - name: Install criu
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ name: Containerd Release
 jobs:
   check:
     name: Check Signed Tag
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 5
     outputs:
       stringver: ${{ steps.contentrel.outputs.stringver }}
@@ -36,29 +36,31 @@ jobs:
 
   build:
     name: Build Release Binaries
-    runs-on: ubuntu-${{ matrix.ubuntu }}
+    runs-on: ubuntu-20.04
     needs: [check]
     timeout-minutes: 30
     strategy:
       matrix:
         include:
           # Choose an old release of Ubuntu to avoid glibc issue https://github.com/containerd/containerd/issues/7255
-          - ubuntu: 18.04
-            platform: linux/amd64
-          - ubuntu: 18.04
-            platform: linux/arm64
-          - ubuntu: 18.04
-            platform: linux/ppc64le
-          - ubuntu: 18.04
-            platform: linux/s390x
+          - dockerfile-ubuntu: 18.04
+            dockerfile-platform: linux/amd64
+          - dockerfile-ubuntu: 18.04
+            dockerfile-platform: linux/arm64
+          - dockerfile-ubuntu: 18.04
+            dockerfile-platform: linux/ppc64le
+          - dockerfile-ubuntu: 18.04
+            dockerfile-platform: linux/s390x
           # riscv64 isn't supported by Ubuntu 18.04
-          - ubuntu: 22.04
-            platform: linux/riscv64
+          - dockerfile-ubuntu: 22.04
+            dockerfile-platform: linux/riscv64
+          - dockerfile-ubuntu: 18.04
+            dockerfile-platform: windows/amd64
     steps:
       - name: Set env
         shell: bash
         env:
-          MOS: ubuntu-${{ matrix.ubuntu }}
+          MOS: ubuntu-20.04
         run: |
           releasever=${{ github.ref }}
           releasever="${releasever#refs/tags/}"
@@ -90,15 +92,14 @@ jobs:
             export PREFIX_LEN=12
             BUILD_ARGS="--build-arg GATEWAY --build-arg PREFIX_LEN"
           fi
-          docker buildx build ${cache} --build-arg RELEASE_VER --build-arg UBUNTU_VERSION=${{ matrix.ubuntu }} --build-arg GO_VERSION ${BUILD_ARGS} -f .github/workflows/release/Dockerfile --platform=${PLATFORM} -o releases/ .
+          docker buildx build ${cache} --build-arg RELEASE_VER --build-arg UBUNTU_VERSION=${{ matrix.dockerfile-ubuntu }} --build-arg GO_VERSION ${BUILD_ARGS} -f .github/workflows/release/Dockerfile --platform=${PLATFORM} -o releases/ .
           echo PLATFORM_CLEAN=${PLATFORM/\//-} >> $GITHUB_ENV
 
           # Remove symlinks since we don't want these in the release Artifacts
           find ./releases/ -maxdepth 1 -type l | xargs rm
         working-directory: src/github.com/confidential-containers/containerd
         env:
-          GO_VERSION: '1.17.13'
-          PLATFORM: ${{ matrix.platform }}
+          PLATFORM: ${{ matrix.dockerfile-platform }}
       - name: Save Artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -107,7 +108,7 @@ jobs:
 
   release:
     name: Create containerd Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
     needs: [build, check]
     steps:


### PR DESCRIPTION
The release binaries are built using Ubuntu 18.04 in Docker on Ubuntu 20.04 for glibc compatibility reason (issue 7255).

Fix issue 7297