### PR TITLE
release: Bump plugins and add permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
           path: src/github.com/confidential-containers/containerd
@@ -30,12 +30,12 @@ jobs:
         id: contentrel
         run: |
           RELEASEVER=${{ github.ref }}
-          echo "::set-output name=stringver::${RELEASEVER#refs/tags/v}"
+          echo "stringver=${RELEASEVER#refs/tags/v}" >> $GITHUB_OUTPUT
           git tag -l ${RELEASEVER#refs/tags/} -n20000 | tail -n +3 | cut -c 5- >release-notes.md
         working-directory: src/github.com/confidential-containers/containerd
 
       - name: Save release notes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: containerd-release-notes
           path: src/github.com/confidential-containers/containerd/release-notes.md
@@ -55,12 +55,14 @@ jobs:
             dockerfile-platform: linux/arm64
           - dockerfile-ubuntu: 18.04
             dockerfile-platform: linux/ppc64le
-          - dockerfile-ubuntu: 18.04
-            dockerfile-platform: linux/s390x
           # riscv64 isn't supported by Ubuntu 18.04
           - dockerfile-ubuntu: 22.04
             dockerfile-platform: linux/riscv64
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
       - name: Set env
         shell: bash
         env:
@@ -71,7 +73,7 @@ jobs:
           echo "RELEASE_VER=${releasever}" >> $GITHUB_ENV
           echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
       - name: Checkout containerd
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Intentionally use github.repository instead of containerd/containerd to
           # make this action runnable on forks.
@@ -105,19 +107,21 @@ jobs:
         env:
           PLATFORM: ${{ matrix.dockerfile-platform }}
       - name: Save Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: release-tars-${{env.PLATFORM_CLEAN}}
           path: src/github.com/confidential-containers/containerd/releases/*.tar.gz*
 
   release:
     name: Create containerd Release
+    permissions:
+      contents: write
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     needs: [build, check]
     steps:
       - name: Download builds and release notes
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: builds
       - name: Create Release


### PR DESCRIPTION
- Fix deprecation warnings
- Release step needs permissions to avoid `
Unexpected error fetching GitHub release for tag
refs/tags/v1.6.8.2: HttpError: Resource not accessible by integration `