### PR TITLE
release: Re-add s390x release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,8 @@ jobs:
             dockerfile-platform: linux/arm64
           - dockerfile-ubuntu: 18.04
             dockerfile-platform: linux/ppc64le
+          - dockerfile-ubuntu: 18.04
+            dockerfile-platform: linux/s390x
           # riscv64 isn't supported by Ubuntu 18.04
           - dockerfile-ubuntu: 22.04
             dockerfile-platform: linux/riscv64


### PR DESCRIPTION
Re-add s390x release which I accidently removed in the last merge from upstream